### PR TITLE
expr add upstream host locality cel value 

### DIFF
--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -230,6 +230,21 @@ absl::optional<CelValue> UpstreamWrapper::operator[](CelValue key) const {
     }
   } else if (value == UpstreamTransportFailureReason) {
     return CelValue::CreateStringView(info_.upstreamTransportFailureReason());
+  } else if (value == UpstreamHostLocalityRegion) {
+    auto upstream_host = info_.upstreamHost();
+    if (upstream_host != nullptr) {
+      return CelValue::CreateString(&upstream_host->locality().region());
+    }
+  } else if (value == UpstreamHostLocalityZone) {
+    auto upstream_host = info_.upstreamHost();
+    if (upstream_host != nullptr) {
+      return CelValue::CreateString(&upstream_host->locality().zone());
+    }
+  } else if (value == UpstreamHostLocalitySubZone) {
+    auto upstream_host = info_.upstreamHost();
+    if (upstream_host != nullptr) {
+      return CelValue::CreateString(&upstream_host->locality().sub_zone());
+    }
   }
 
   auto ssl_info = info_.upstreamSslConnection();

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -76,6 +76,9 @@ constexpr absl::string_view Destination = "destination";
 constexpr absl::string_view Upstream = "upstream";
 constexpr absl::string_view UpstreamLocalAddress = "local_address";
 constexpr absl::string_view UpstreamTransportFailureReason = "transport_failure_reason";
+constexpr absl::string_view UpstreamHostLocalityRegion = "host_locality_region";
+constexpr absl::string_view UpstreamHostLocalityZone = "host_locality_zone";
+constexpr absl::string_view UpstreamHostLocalitySubZone  = "host_locality_sub_zone";
 
 class RequestWrapper;
 

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -456,6 +456,8 @@ TEST(Context, ConnectionAttributes) {
 
   EXPECT_CALL(*downstream_ssl_info, peerCertificatePresented()).WillRepeatedly(Return(true));
   EXPECT_CALL(*upstream_host, address()).WillRepeatedly(Return(upstream_address));
+  envoy::config::core::v3::Locality upstream_locality = Envoy::Upstream::Locality("region", "zone", "sub_zone");
+  EXPECT_CALL(*upstream_host, locality()).WillRepeatedly(ReturnRef(upstream_locality));
 
   const std::string tls_version = "TLSv1";
   EXPECT_CALL(*downstream_ssl_info, tlsVersion()).WillRepeatedly(ReturnRef(tls_version));
@@ -544,6 +546,27 @@ TEST(Context, ConnectionAttributes) {
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(679, value.value().Int64OrDie());
+  }
+
+  {
+    auto value = upstream[CelValue::CreateStringView(UpstreamHostLocalityRegion)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ("region", value.value().StringOrDie().value());
+  }
+  
+  {
+    auto value = upstream[CelValue::CreateStringView(UpstreamHostLocalityZone)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ("zone", value.value().StringOrDie().value());
+  }
+  
+  {
+    auto value = upstream[CelValue::CreateStringView(UpstreamHostLocalitySubZone)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ("sub_zone", value.value().StringOrDie().value());
   }
 
   {


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
we want to get upstream host locality at istio stats plugin to note which zone or cluster(sub_zone) the upstream endpoint is. The way to get this is to add cel expr extension at upstream field at context.cc

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
