### PR TITLE
feat: remove cluster both http1 and http2 throw execption checking

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -676,14 +676,6 @@ createOptions(const envoy::config::cluster::v3::Cluster& config,
     return std::move(options);
   }
 
-  if (config.protocol_selection() == envoy::config::cluster::v3::Cluster::USE_CONFIGURED_PROTOCOL) {
-    // Make sure multiple protocol configurations are not present
-    if (config.has_http_protocol_options() && config.has_http2_protocol_options()) {
-      throw EnvoyException(fmt::format("cluster: Both HTTP1 and HTTP2 options may only be "
-                                       "configured with non-default 'protocol_selection' values"));
-    }
-  }
-
   return std::make_shared<ClusterInfoImpl::HttpProtocolOptionsConfigImpl>(
       config.http_protocol_options(), config.http2_protocol_options(),
       config.common_http_protocol_options(),


### PR DESCRIPTION
Signed-off-by: jiangshantao <jiangshantao-dbg@qq.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
