### PR TITLE
Mt feature/cherry pick slow start add min weight percent 1.9.9

### DIFF
--- a/api/envoy/config/cluster/v3/cluster.proto
+++ b/api/envoy/config/cluster/v3/cluster.proto
@@ -348,12 +348,17 @@ message Cluster {
     // By tuning the parameter, is possible to achieve polynomial or exponential shape of ramp-up curve.
     //
     // During slow start window, effective weight of an endpoint would be scaled with time factor and aggression:
-    // `new_weight = weight * time_factor ^ (1 / aggression)`,
+    // `new_weight = weight * max(min_weight_percent, time_factor ^ (1 / aggression))`,
     // where `time_factor=(time_since_start_seconds / slow_start_time_seconds)`.
     //
     // As time progresses, more and more traffic would be sent to endpoint, which is in slow start window.
     // Once host exits slow start, time_factor and aggression no longer affect its weight.
     core.v3.RuntimeDouble aggression = 2;
+
+    // Configures the minimum percentage of origin weight that avoids too small new weight,
+    // which may cause endpoints in slow start mode receive no traffic in slow start window.
+    // If not specified, the default is 10%.
+    type.v3.Percent min_weight_percent = 3;
   }
 
   // Specific configuration for the RoundRobin load balancing policy.

--- a/api/envoy/config/cluster/v4alpha/cluster.proto
+++ b/api/envoy/config/cluster/v4alpha/cluster.proto
@@ -352,12 +352,17 @@ message Cluster {
     // By tuning the parameter, is possible to achieve polynomial or exponential shape of ramp-up curve.
     //
     // During slow start window, effective weight of an endpoint would be scaled with time factor and aggression:
-    // `new_weight = weight * time_factor ^ (1 / aggression)`,
+    // `new_weight = weight * max(min_weight_percent, time_factor ^ (1 / aggression))`,
     // where `time_factor=(time_since_start_seconds / slow_start_time_seconds)`.
     //
     // As time progresses, more and more traffic would be sent to endpoint, which is in slow start window.
     // Once host exits slow start, time_factor and aggression no longer affect its weight.
     core.v4alpha.RuntimeDouble aggression = 2;
+
+    // Configures the minimum percentage of origin weight that avoids too small new weight,
+    // which may cause endpoints in slow start mode receive no traffic in slow start window.
+    // If not specified, the default is 10%.
+    type.v3.Percent min_weight_percent = 3;
   }
 
   // Specific configuration for the RoundRobin load balancing policy.

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -134,7 +134,6 @@ message Http1ProtocolOptions {
 
       // Configuration for stateful formatter extensions that allow using received headers to
       // affect the output of encoding headers. E.g., preserving case during proxying.
-      // [#extension-category: envoy.http.stateful_header_formatters]
       TypedExtensionConfig stateful_formatter = 8;
     }
   }

--- a/api/envoy/config/core/v4alpha/protocol.proto
+++ b/api/envoy/config/core/v4alpha/protocol.proto
@@ -134,7 +134,6 @@ message Http1ProtocolOptions {
 
       // Configuration for stateful formatter extensions that allow using received headers to
       // affect the output of encoding headers. E.g., preserving case during proxying.
-      // [#extension-category: envoy.http.stateful_header_formatters]
       TypedExtensionConfig stateful_formatter = 8;
     }
   }

--- a/docs/root/intro/arch_overview/upstream/load_balancing/slow_start.rst
+++ b/docs/root/intro/arch_overview/upstream/load_balancing/slow_start.rst
@@ -15,7 +15,7 @@ During slow start window, load balancing weight of a particular endpoint will be
 
 .. math::
 
-  NewWeight = {Weight*TimeFactor}^\frac{1}{Aggression}
+  NewWeight = {Weight}*{max(MinWeightPercent,{TimeFactor}^\frac{1}{Aggression})}
 
 where,
 
@@ -24,6 +24,8 @@ where,
   TimeFactor = \frac{max(TimeSinceStartInSeconds,1)}{SlowStartWindowInSeconds}
 
 As time progresses, more and more traffic would be sent to endpoint within slow start window.
+
+:ref:`MinWeightPercent parameter<envoy_v3_api_field_config.cluster.v3.Cluster.SlowStartConfig.min_weight_percent>` specifies the minimum percent of origin weight to make sure the EDF scheduler has a reasonable deadline, default is 10%.
 
 :ref:`Aggression parameter<envoy_v3_api_field_config.cluster.v3.Cluster.SlowStartConfig.aggression>` non-linearly affects endpoint weight and represents the speed of ramp-up.
 By tuning aggression parameter, one could achieve polynomial or exponential speed for traffic increase.

--- a/docs/root/version_history/current.rst
+++ b/docs/root/version_history/current.rst
@@ -26,6 +26,7 @@ Bug Fixes
 * ext_authz: fix the ext_authz filter to correctly merge multiple same headers using the ',' as separator in the check request to the external authorization service.
 * http: limit use of deferred resets in the http2 codec to server-side connections. Use of deferred reset for client connections can result in incorrect behavior and performance problems.
 * jwt_authn: unauthorized responses now correctly include a `www-authenticate` header.
+* upstream: cluster slow start config add ``min_weight_percent`` field to avoid too big EDF deadline which cause slow start endpoints receiving no traffic, default 10%. This fix is releted to `issue#19526 <https://github.com/envoyproxy/envoy/issues/19526>`_.
 
 Removed Config or Runtime
 -------------------------

--- a/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v3/cluster.proto
@@ -348,12 +348,17 @@ message Cluster {
     // By tuning the parameter, is possible to achieve polynomial or exponential shape of ramp-up curve.
     //
     // During slow start window, effective weight of an endpoint would be scaled with time factor and aggression:
-    // `new_weight = weight * time_factor ^ (1 / aggression)`,
+    // `new_weight = weight * max(min_weight_percent, time_factor ^ (1 / aggression))`,
     // where `time_factor=(time_since_start_seconds / slow_start_time_seconds)`.
     //
     // As time progresses, more and more traffic would be sent to endpoint, which is in slow start window.
     // Once host exits slow start, time_factor and aggression no longer affect its weight.
     core.v3.RuntimeDouble aggression = 2;
+
+    // Configures the minimum percentage of origin weight that avoids too small new weight,
+    // which may cause endpoints in slow start mode receive no traffic in slow start window.
+    // If not specified, the default is 10%.
+    type.v3.Percent min_weight_percent = 3;
   }
 
   // Specific configuration for the RoundRobin load balancing policy.

--- a/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
+++ b/generated_api_shadow/envoy/config/cluster/v4alpha/cluster.proto
@@ -353,12 +353,17 @@ message Cluster {
     // By tuning the parameter, is possible to achieve polynomial or exponential shape of ramp-up curve.
     //
     // During slow start window, effective weight of an endpoint would be scaled with time factor and aggression:
-    // `new_weight = weight * time_factor ^ (1 / aggression)`,
+    // `new_weight = weight * max(min_weight_percent, time_factor ^ (1 / aggression))`,
     // where `time_factor=(time_since_start_seconds / slow_start_time_seconds)`.
     //
     // As time progresses, more and more traffic would be sent to endpoint, which is in slow start window.
     // Once host exits slow start, time_factor and aggression no longer affect its weight.
     core.v4alpha.RuntimeDouble aggression = 2;
+
+    // Configures the minimum percentage of origin weight that avoids too small new weight,
+    // which may cause endpoints in slow start mode receive no traffic in slow start window.
+    // If not specified, the default is 10%.
+    type.v3.Percent min_weight_percent = 3;
   }
 
   // Specific configuration for the RoundRobin load balancing policy.

--- a/generated_api_shadow/envoy/config/core/v3/protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v3/protocol.proto
@@ -134,7 +134,6 @@ message Http1ProtocolOptions {
 
       // Configuration for stateful formatter extensions that allow using received headers to
       // affect the output of encoding headers. E.g., preserving case during proxying.
-      // [#extension-category: envoy.http.stateful_header_formatters]
       TypedExtensionConfig stateful_formatter = 8;
     }
   }

--- a/generated_api_shadow/envoy/config/core/v4alpha/protocol.proto
+++ b/generated_api_shadow/envoy/config/core/v4alpha/protocol.proto
@@ -134,7 +134,6 @@ message Http1ProtocolOptions {
 
       // Configuration for stateful formatter extensions that allow using received headers to
       // affect the output of encoding headers. E.g., preserving case during proxying.
-      // [#extension-category: envoy.http.stateful_header_formatters]
       TypedExtensionConfig stateful_formatter = 8;
     }
   }

--- a/source/common/upstream/load_balancer_impl.h
+++ b/source/common/upstream/load_balancer_impl.h
@@ -428,6 +428,7 @@ protected:
   const absl::optional<Runtime::Double> aggression_runtime_;
   TimeSource& time_source_;
   MonotonicTime latest_host_added_time_;
+  const double slow_start_min_weight_percent_;
 };
 
 /**

--- a/test/common/upstream/load_balancer_impl_test.cc
+++ b/test/common/upstream/load_balancer_impl_test.cc
@@ -42,6 +42,9 @@ public:
     return std::chrono::time_point_cast<std::chrono::milliseconds>(edf_lb.latest_host_added_time_)
         .time_since_epoch();
   }
+  static double slowStartMinWeightPercent(const EdfLoadBalancerBase& edf_lb) {
+    return edf_lb.slow_start_min_weight_percent_;
+  }
 };
 
 namespace {
@@ -1486,6 +1489,26 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartWithDefaultParams) {
   const auto latest_host_added_time =
       EdfLoadBalancerBasePeer::latestHostAddedTime(static_cast<EdfLoadBalancerBase&>(*lb_));
   EXPECT_EQ(std::chrono::milliseconds(0), latest_host_added_time);
+  const auto slow_start_min_weight_percent =
+      EdfLoadBalancerBasePeer::slowStartMinWeightPercent(static_cast<EdfLoadBalancerBase&>(*lb_));
+  EXPECT_DOUBLE_EQ(slow_start_min_weight_percent, 0.1);
+}
+
+TEST_P(RoundRobinLoadBalancerTest, SlowStartWithMinWeightPercent) {
+  round_robin_lb_config_.mutable_slow_start_config()->mutable_min_weight_percent()->set_value(30);
+  init(false);
+  const auto slow_start_window =
+      EdfLoadBalancerBasePeer::slowStartWindow(static_cast<EdfLoadBalancerBase&>(*lb_));
+  EXPECT_EQ(std::chrono::milliseconds(0), slow_start_window);
+  const auto aggression =
+      EdfLoadBalancerBasePeer::aggression(static_cast<EdfLoadBalancerBase&>(*lb_));
+  EXPECT_EQ(1.0, aggression);
+  const auto latest_host_added_time =
+      EdfLoadBalancerBasePeer::latestHostAddedTime(static_cast<EdfLoadBalancerBase&>(*lb_));
+  EXPECT_EQ(std::chrono::milliseconds(0), latest_host_added_time);
+  const auto slow_start_min_weight_percent =
+      EdfLoadBalancerBasePeer::slowStartMinWeightPercent(static_cast<EdfLoadBalancerBase&>(*lb_));
+  EXPECT_DOUBLE_EQ(slow_start_min_weight_percent, 0.3);
 }
 
 TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWait) {
@@ -1522,7 +1545,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWait) {
       EdfLoadBalancerBasePeer::latestHostAddedTime(static_cast<EdfLoadBalancerBase&>(*lb_));
   EXPECT_EQ(std::chrono::milliseconds(62000), latest_host_added_time_ms);
 
-  // host2 is 12 secs in slow start, the weight is scaled with time factor 12 / 60 == 0.2.
+  // host2 is 12 secs in slow start, the weight is scaled with time factor max(12 / 60, 0.1) = 0.2.
   simTime().advanceTimeWait(std::chrono::seconds(12));
 
   // Recalculate weights.
@@ -1609,7 +1632,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartWaitForPassingHC) {
   hostSet().runCallbacks({}, {});
 
   // We expect 3:1 ratio, as host2 is in slow start mode, its weight is scaled with time factor
-  // 5 / 10 == 0.5.
+  // max(6/10, 0.1) = 0.6.
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
@@ -1653,7 +1676,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartWithRuntimeAggression) {
   EXPECT_EQ(std::chrono::milliseconds(1000), latest_host_added_time_ms);
 
   // We should see 2:1:1 ratio, as hosts 2 and 3 are in slow start, their weights are scaled with
-  // 0.5 factor.
+  // max(0.5,0.1)=0.5 factor.
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
@@ -1673,8 +1696,8 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartWithRuntimeAggression) {
       EdfLoadBalancerBasePeer::latestHostAddedTime(static_cast<EdfLoadBalancerBase&>(*lb_));
   EXPECT_EQ(std::chrono::milliseconds(10000), latest_host_added_time_ms);
 
-  // We should see 1:1:1:0 ratio, as host 2 and 3 weight is scaled with (9/10)^(1/1.5)=0.93 factor,
-  // host4 weight is 0.002.
+  // We should see 1:1:1:0 ratio, as host 2 and 3 weight is scaled with max((9/10)^(1/1.5),0.1)=0.93
+  // factor, host4 weight is 1*max(0.002,0.1)=0.1.
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
@@ -1682,7 +1705,8 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartWithRuntimeAggression) {
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[2], lb_->chooseHost(nullptr));
 
-  // host4 is 9 seconds in slow start, it's weight is scaled with (9/10)^(1/1.5)=0.93 factor.
+  // host4 is 9 seconds in slow start, it's weight is scaled with max((9/10)^(1/1.5), 0.1)=0.93
+  // factor.
   simTime().advanceTimeWait(std::chrono::seconds(9));
   hostSet().runCallbacks({}, {});
 
@@ -1707,7 +1731,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitNonLinearAggression) {
   hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   simTime().advanceTimeWait(std::chrono::seconds(5));
-  // Host1 is 5 secs in slow start, its weight is scaled with (0.5/60)^(1/2)=0.28 factor.
+  // Host1 is 5 secs in slow start, its weight is scaled with max((5/60)^(1/2), 0.1)=0.28 factor.
   hostSet().runCallbacks({}, {});
 
   // Advance time, so that host1 is no longer in slow start.
@@ -1720,7 +1744,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitNonLinearAggression) {
 
   hostSet().healthy_hosts_.push_back(host2);
   hostSet().hosts_ = hostSet().healthy_hosts_;
-  // host2 weight is scaled with 0.004 factor.
+  // host2 weight is scaled with max((0.001/60)^(1/2), 0.1)=max(0.004, 0.1)=0.1 factor.
   hostSet().runCallbacks(hosts_added, {});
 
   // host2 is 6 secs in slow start.
@@ -1730,7 +1754,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitNonLinearAggression) {
   hostSet().runCallbacks({}, {});
 
   // We expect 3:1 ratio, as host2 is 6 secs in slow start mode and it's weight is scaled with
-  // pow(0.1, 0.5)==0.31 factor.
+  // max(pow(0.1, 0.5), 0.1)=0.31 factor.
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
@@ -1743,7 +1767,7 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitNonLinearAggression) {
   hostSet().runCallbacks({}, {});
 
   // We still expect 5:3 ratio, as host2 is in slow start mode and it's weight is scaled with
-  // pow(0.43, 0.5)==0.65 factor.
+  // max(pow(0.43, 0.5), 0.1)=0.65 factor.
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
@@ -1758,6 +1782,102 @@ TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitNonLinearAggression) {
 
   // Recalculate weights.
   hostSet().runCallbacks({}, {});
+
+  // Now expect 1:1 ratio.
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_->chooseHost(nullptr));
+}
+
+TEST_P(RoundRobinLoadBalancerTest, SlowStartNoWaitMinWeightPercent35) {
+  round_robin_lb_config_.mutable_slow_start_config()->mutable_slow_start_window()->set_seconds(60);
+  round_robin_lb_config_.mutable_slow_start_config()->mutable_min_weight_percent()->set_value(35);
+  simTime().advanceTimeWait(std::chrono::seconds(1));
+  auto host1 = makeTestHost(info_, "tcp://127.0.0.1:80", simTime());
+  host_set_.hosts_ = {host1};
+
+  init(true);
+
+  // As no healthcheck is configured, hosts would enter slow start immediately.
+  HostVector empty;
+  HostVector hosts_added;
+  hosts_added.push_back(host1);
+  simTime().advanceTimeWait(std::chrono::seconds(5));
+  hostSet().runCallbacks(hosts_added, empty);
+  auto latest_host_added_time_ms =
+      EdfLoadBalancerBasePeer::latestHostAddedTime(static_cast<EdfLoadBalancerBase&>(*lb_));
+  EXPECT_EQ(std::chrono::milliseconds(1000), latest_host_added_time_ms);
+
+  // Advance time, so that host is no longer in slow start.
+  simTime().advanceTimeWait(std::chrono::seconds(56));
+
+  hosts_added.clear();
+  auto host2 = makeTestHost(info_, "tcp://127.0.0.1:90", simTime());
+
+  hosts_added.push_back(host2);
+
+  hostSet().healthy_hosts_ = {host1, host2};
+  hostSet().hosts_ = hostSet().healthy_hosts_;
+  hostSet().runCallbacks(hosts_added, empty);
+
+  latest_host_added_time_ms =
+      EdfLoadBalancerBasePeer::latestHostAddedTime(static_cast<EdfLoadBalancerBase&>(*lb_));
+  EXPECT_EQ(std::chrono::milliseconds(62000), latest_host_added_time_ms);
+
+  // host2 is 12 secs in slow start, the weight is scaled with time factor max(12 / 60, 0.35) =
+  // 0.35.
+  simTime().advanceTimeWait(std::chrono::seconds(12));
+
+  // Recalculate weights.
+  hostSet().runCallbacks(empty, empty);
+
+  // We expect 5:2 ratio, as host2 is in slow start mode and it's weight is scaled with
+  // 0.35 factor.
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[1,20/7]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[2,20/7]
+  EXPECT_EQ(hostSet().healthy_hosts_[1],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[3,20/7]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[3,40/7]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[4,40/7]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[5,40/7]
+  EXPECT_EQ(hostSet().healthy_hosts_[1],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[6,40/7]
+
+  // host2 is 30 secs in slow start, the weight is scaled with time factor max(30 / 60, 0.35) ==
+  // 0.5.
+  simTime().advanceTimeWait(std::chrono::seconds(18));
+
+  // Recalculate weights.
+  hostSet().runCallbacks(empty, empty);
+
+  // We expect 2:1 ratio, as host2 is in slow start mode and it's weight is scaled with
+  // 0.5 factor.
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[1,2]
+  EXPECT_EQ(hostSet().healthy_hosts_[1],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[2,2]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[2,4]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[3,4]
+  EXPECT_EQ(hostSet().healthy_hosts_[1],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[4,4]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[4,6]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_->chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[5,6]
+
+  // Advance time, so that there are no hosts in slow start.
+  simTime().advanceTimeWait(std::chrono::seconds(45));
+
+  // Recalculate weights.
+  hostSet().runCallbacks(empty, empty);
 
   // Now expect 1:1 ratio.
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_->chooseHost(nullptr));
@@ -2040,6 +2160,9 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartWithDefaultParams) {
   const auto latest_host_added_time =
       EdfLoadBalancerBasePeer::latestHostAddedTime(static_cast<EdfLoadBalancerBase&>(lb_2));
   EXPECT_EQ(std::chrono::milliseconds(0), latest_host_added_time);
+  const auto slow_start_min_weight_percent =
+      EdfLoadBalancerBasePeer::slowStartMinWeightPercent(static_cast<EdfLoadBalancerBase&>(lb_2));
+  EXPECT_DOUBLE_EQ(slow_start_min_weight_percent, 0.1);
 }
 
 TEST_P(LeastRequestLoadBalancerTest, SlowStartNoWait) {
@@ -2055,7 +2178,7 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartNoWait) {
   hostSet().healthy_hosts_ = {makeTestHost(info_, "tcp://127.0.0.1:80", simTime())};
   hostSet().hosts_ = hostSet().healthy_hosts_;
   simTime().advanceTimeWait(std::chrono::seconds(5));
-  // Host1 is 5 secs in slow start, its weight is scaled with (5/60)^1=0.08 factor.
+  // Host1 is 5 secs in slow start, its weight is scaled with max((5/60)^1, 0.1)=0.1 factor.
   hostSet().runCallbacks({}, {});
 
   auto latest_host_added_time =
@@ -2077,7 +2200,7 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartNoWait) {
       EdfLoadBalancerBasePeer::latestHostAddedTime(static_cast<EdfLoadBalancerBase&>(lb_2));
   EXPECT_EQ(std::chrono::milliseconds(62000), latest_host_added_time);
 
-  // host2 is 20 secs in slow start, the weight is scaled with time factor 20 / 60 == 0.16.
+  // host2 is 20 secs in slow start, the weight is scaled with time factor max(20/60, 0.1) = 0.16.
   simTime().advanceTimeWait(std::chrono::seconds(10));
 
   // Recalculate weights.
@@ -2093,7 +2216,7 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartNoWait) {
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_2.chooseHost(nullptr));
 
-  // host2 is 50 secs in slow start, the weight is scaled with time factor 40 / 60 == 0.66.
+  // host2 is 50 secs in slow start, the weight is scaled with time factor max(40/60, 0.1) = 0.66.
   simTime().advanceTimeWait(std::chrono::seconds(30));
 
   // Recalculate weights.
@@ -2164,22 +2287,35 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartWaitForPassingHC) {
   hostSet().runCallbacks({}, {});
 
   // We expect 11:2 ratio, as host2 is in slow start mode, its weight is scaled with factor
-  // pow(0.1, 1.11)=0.07. Host1 is 7 seconds in slow start and its weight is scaled with active
-  // request and time bias 0.53 * pow(0.7, 1.11) = 0.36.
+  // max(pow(0.1, 1.11), 0.1)=0.1. Host1 is 7 seconds in slow start and its weight is scaled with
+  // active request and time bias 0.53 * max(pow(0.7, 1.11), 0.1) = 0.36.
 
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[1], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
-  EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[25/9, 10]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[50/9, 10]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[75/9, 10]
+  EXPECT_EQ(hostSet().healthy_hosts_[1],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[100/9, 10]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[100/9, 20]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[125/9, 20]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[150/9, 20]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[175/9, 20]
+  EXPECT_EQ(hostSet().healthy_hosts_[1],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[200/9, 20]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[200/9, 30]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[225/9, 30]
+  EXPECT_EQ(hostSet().healthy_hosts_[0],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[250/9, 30]
+  EXPECT_EQ(hostSet().healthy_hosts_[1],
+            lb_2.chooseHost(nullptr)); // before choose: edf.deadline[host1,host2]=[275/9, 30]
 
   simTime().advanceTimeWait(std::chrono::seconds(3));
   host1->healthFlagSet(Host::HealthFlag::FAILED_ACTIVE_HC);
@@ -2187,7 +2323,7 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartWaitForPassingHC) {
   hostSet().runCallbacks({}, {});
 
   // We expect 3:5 ratio, as host2 is 4 seconds in slow start, its weight is scaled with factor
-  // pow(0.4, 1.11)=0.36. Host1 is not in slow start and its weight is scaled with active
+  // max(pow(0.4, 1.11), 0.1)=0.36. Host1 is not in slow start and its weight is scaled with active
   // request bias = 0.53.
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_2.chooseHost(nullptr));
@@ -2198,13 +2334,13 @@ TEST_P(LeastRequestLoadBalancerTest, SlowStartWaitForPassingHC) {
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_2.chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
 
-  // Host2 is 7 seconds in slow start, the weight is scaled with time factor 7 / 10 == 0.6.
+  // Host2 is 7 seconds in slow start, the weight is scaled with time factor 7 / 10 == 0.7.
   simTime().advanceTimeWait(std::chrono::seconds(3));
 
   hostSet().runCallbacks({}, {});
 
   // We expect 6:5 ratio, as host2 is in slow start mode, its weight is scaled with time factor
-  // pow(0.7, 1.11)=0.67. Host1 weight is scaled with active request bias = 0.53.
+  // max(pow(0.7, 1.11), 0.1)=0.67. Host1 weight is scaled with active request bias = 0.53.
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_2.chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[0], lb_2.chooseHost(nullptr));
   EXPECT_EQ(hostSet().healthy_hosts_[1], lb_2.chooseHost(nullptr));


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

slow start config add min_weight_percent field

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
