### PR TITLE
Feature/preserve case support formatter on unknown headers  (#20780)

### DIFF
--- a/api/envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.proto
+++ b/api/envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.http.header_formatters.preserve_case.v3;
 
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.http.header_formatters.preserve_case.v3";
 option java_outer_classname = "PreserveCaseProto";
@@ -16,4 +17,22 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // See the :ref:`header casing <config_http_conn_man_header_casing>` configuration guide for more
 // information.
 message PreserveCaseFormatterConfig {
+  enum FormatterTypeOnEnvoyHeaders {
+    // Use LowerCase on Envoy added headers.
+    DEFAULT = 0;
+
+    // Use ProperCaseHeaderKeyFormatter on Envoy added headers that upper cases the first character
+    // in each word. The first character as well as any alpha character following a special
+    // character is upper cased.
+    PROPER_CASE = 1;
+  }
+
+  // Allows forwarding reason phrase text.
+  // This is off by default, and a standard reason phrase is used for a corresponding HTTP response code.
+  bool forward_reason_phrase = 1;
+
+  // Type of formatter to use on headers which are added by Envoy (which are lower case by default).
+  // The default type is DEFAULT, use LowerCase on Envoy headers.
+  FormatterTypeOnEnvoyHeaders formatter_type_on_envoy_headers = 2
+      [(validate.rules).enum = {defined_only: true}];
 }

--- a/generated_api_shadow/envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.proto
+++ b/generated_api_shadow/envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package envoy.extensions.http.header_formatters.preserve_case.v3;
 
 import "udpa/annotations/status.proto";
+import "validate/validate.proto";
 
 option java_package = "io.envoyproxy.envoy.extensions.http.header_formatters.preserve_case.v3";
 option java_outer_classname = "PreserveCaseProto";
@@ -16,4 +17,22 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // See the :ref:`header casing <config_http_conn_man_header_casing>` configuration guide for more
 // information.
 message PreserveCaseFormatterConfig {
+  enum FormatterTypeOnEnvoyHeaders {
+    // Use LowerCase on Envoy added headers.
+    DEFAULT = 0;
+
+    // Use ProperCaseHeaderKeyFormatter on Envoy added headers that upper cases the first character
+    // in each word. The first character as well as any alpha character following a special
+    // character is upper cased.
+    PROPER_CASE = 1;
+  }
+
+  // Allows forwarding reason phrase text.
+  // This is off by default, and a standard reason phrase is used for a corresponding HTTP response code.
+  bool forward_reason_phrase = 1;
+
+  // Type of formatter to use on headers which are added by Envoy (which are lower case by default).
+  // The default type is DEFAULT, use LowerCase on Envoy headers.
+  FormatterTypeOnEnvoyHeaders formatter_type_on_envoy_headers = 2
+      [(validate.rules).enum = {defined_only: true}];
 }

--- a/include/envoy/http/header_formatter.h
+++ b/include/envoy/http/header_formatter.h
@@ -33,6 +33,16 @@ public:
    * Called for each header key received by the codec.
    */
   virtual void processKey(absl::string_view key) PURE;
+
+  /**
+   * Called to save received reason phrase
+   */
+  virtual void setReasonPhrase(absl::string_view reason_phrase) PURE;
+
+  /**
+   * Called to get saved reason phrase
+   */
+  virtual absl::string_view getReasonPhrase() const PURE;
 };
 
 using StatefulHeaderKeyFormatterPtr = std::unique_ptr<StatefulHeaderKeyFormatter>;

--- a/source/extensions/extensions_build_config.bzl
+++ b/source/extensions/extensions_build_config.bzl
@@ -243,7 +243,7 @@ EXTENSIONS = {
     # HTTP header formatters
     #
 
-    "envoy.http.stateful_header_formatters.preserve_case":       "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter"
+    "envoy.http.stateful_header_formatters.preserve_case":       "//source/extensions/http/header_formatters/preserve_case:config"
 }
 
 # These can be changed to ["//visibility:public"], for  downstream builds which

--- a/source/extensions/http/header_formatters/preserve_case/BUILD
+++ b/source/extensions/http/header_formatters/preserve_case/BUILD
@@ -14,8 +14,21 @@ envoy_cc_extension(
     hdrs = ["preserve_case_formatter.h"],
     security_posture = "robust_to_untrusted_downstream_and_upstream",
     deps = [
-        "//include/envoy/registry",
+        "//source/common/common:utility_lib",
         "//source/common/http/http1:header_formatter_lib",
+        "@envoy_api//envoy/extensions/http/header_formatters/preserve_case/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    security_posture = "robust_to_untrusted_downstream_and_upstream",
+    deps = [
+        ":preserve_case_formatter",
+        "//include/envoy/registry",
+        "//source/common/protobuf:utility_lib",
         "@envoy_api//envoy/extensions/http/header_formatters/preserve_case/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/http/header_formatters/preserve_case/config.cc
+++ b/source/extensions/http/header_formatters/preserve_case/config.cc
@@ -1,0 +1,32 @@
+#include "extensions/http/header_formatters/preserve_case/config.h"
+
+#include "envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.pb.validate.h"
+#include "envoy/registry/registry.h"
+
+#include "common/protobuf/message_validator_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Http {
+namespace HeaderFormatters {
+namespace PreserveCase {
+
+Envoy::Http::StatefulHeaderKeyFormatterFactorySharedPtr
+PreserveCaseFormatterFactoryConfig::createFromProto(const Protobuf::Message& message) {
+  auto config =
+      MessageUtil::downcastAndValidate<const envoy::extensions::http::header_formatters::
+                                           preserve_case::v3::PreserveCaseFormatterConfig&>(
+          message, ProtobufMessage::getStrictValidationVisitor());
+
+  return std::make_shared<PreserveCaseFormatterFactory>(config.forward_reason_phrase(),
+                                                        config.formatter_type_on_envoy_headers());
+}
+
+REGISTER_FACTORY(PreserveCaseFormatterFactoryConfig,
+                 Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig);
+
+} // namespace PreserveCase
+} // namespace HeaderFormatters
+} // namespace Http
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/http/header_formatters/preserve_case/config.h
+++ b/source/extensions/http/header_formatters/preserve_case/config.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.pb.h"
+#include "envoy/http/header_formatter.h"
+
+#include "common/protobuf/utility.h"
+#include "extensions/http/header_formatters/preserve_case/preserve_case_formatter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Http {
+namespace HeaderFormatters {
+namespace PreserveCase {
+
+class PreserveCaseFormatterFactory : public Envoy::Http::StatefulHeaderKeyFormatterFactory {
+public:
+  PreserveCaseFormatterFactory(
+      const bool forward_reason_phrase,
+      const envoy::extensions::http::header_formatters::preserve_case::v3::
+          PreserveCaseFormatterConfig::FormatterTypeOnEnvoyHeaders formatter_type_on_envoy_headers)
+      : forward_reason_phrase_(forward_reason_phrase),
+        formatter_type_on_envoy_headers_(formatter_type_on_envoy_headers) {}
+
+  // Envoy::Http::StatefulHeaderKeyFormatterFactory
+  Envoy::Http::StatefulHeaderKeyFormatterPtr create() override {
+    return std::make_unique<PreserveCaseHeaderFormatter>(forward_reason_phrase_,
+                                                         formatter_type_on_envoy_headers_);
+  }
+
+private:
+  const bool forward_reason_phrase_;
+  const envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+      FormatterTypeOnEnvoyHeaders formatter_type_on_envoy_headers_;
+};
+
+class PreserveCaseFormatterFactoryConfig
+    : public Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig {
+public:
+  // Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig
+  std::string name() const override { return "preserve_case"; }
+
+  Envoy::Http::StatefulHeaderKeyFormatterFactorySharedPtr
+  createFromProto(const Protobuf::Message& message) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<envoy::extensions::http::header_formatters::preserve_case::v3::
+                                PreserveCaseFormatterConfig>();
+  }
+};
+
+} // namespace PreserveCase
+} // namespace HeaderFormatters
+} // namespace Http
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.cc
+++ b/source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.cc
@@ -1,28 +1,44 @@
 #include "extensions/http/header_formatters/preserve_case/preserve_case_formatter.h"
 
-#include "envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.pb.h"
-#include "envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.pb.validate.h"
-#include "envoy/registry/registry.h"
-
 namespace Envoy {
 namespace Extensions {
 namespace Http {
 namespace HeaderFormatters {
 namespace PreserveCase {
 
+PreserveCaseHeaderFormatter::PreserveCaseHeaderFormatter(
+    const bool forward_reason_phrase,
+    const envoy::extensions::http::header_formatters::preserve_case::v3::
+        PreserveCaseFormatterConfig::FormatterTypeOnEnvoyHeaders formatter_type_on_envoy_headers)
+    : forward_reason_phrase_(forward_reason_phrase),
+      formatter_type_on_envoy_headers_(formatter_type_on_envoy_headers) {
+  switch (formatter_type_on_envoy_headers_) {
+  case envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+      DEFAULT:
+    header_key_formatter_on_enovy_headers_ = Envoy::Http::HeaderKeyFormatterConstPtr();
+    break;
+  case envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+      PROPER_CASE:
+    header_key_formatter_on_enovy_headers_ =
+        std::make_unique<Envoy::Http::Http1::ProperCaseHeaderKeyFormatter>();
+    break;
+  default:
+    throw EnvoyException(fmt::format("Not supported FormatterTypeOnEnvoyHeaders: {}.",
+                                     formatter_type_on_envoy_headers_));
+  }
+}
+
 std::string PreserveCaseHeaderFormatter::format(absl::string_view key) const {
   const auto remembered_key_itr = original_header_keys_.find(key);
   // TODO(mattklein123): We can avoid string copies here if the formatter interface allowed us
   // to return something like GetAllOfHeaderAsStringResult with both a string_view and an
   // optional backing string. We can do this in a follow up if there is interest.
-  // TODO(mattklein123): This implementation does not cover headers added by Envoy that may need
-  // do be in a different case. We can handle this in the future by extending this formatter to
-  // have an "inner formatter" that would allow performing proper case (for example) on unknown
-  // headers.
   if (remembered_key_itr != original_header_keys_.end()) {
     return *remembered_key_itr;
+  } else if (formatterOnEnvoyHeaders().has_value()) {
+    return formatterOnEnvoyHeaders()->format(key);
   } else {
-    return proper_case_header_key_formatter_.format(key);
+    return std::string(key);
   }
 }
 
@@ -34,31 +50,18 @@ void PreserveCaseHeaderFormatter::processKey(absl::string_view key) {
   original_header_keys_.emplace(key);
 }
 
-class PreserveCaseFormatterFactory : public Envoy::Http::StatefulHeaderKeyFormatterFactory {
-public:
-  // Envoy::Http::StatefulHeaderKeyFormatterFactory
-  Envoy::Http::StatefulHeaderKeyFormatterPtr create() override {
-    return std::make_unique<PreserveCaseHeaderFormatter>();
+void PreserveCaseHeaderFormatter::setReasonPhrase(absl::string_view reason_phrase) {
+  if (forward_reason_phrase_) {
+    reason_phrase_ = std::string(reason_phrase);
   }
 };
 
-class PreserveCaseFormatterFactoryConfig
-    : public Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig {
-public:
-  // Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig
-  std::string name() const override { return "preserve_case"; }
-  Envoy::Http::StatefulHeaderKeyFormatterFactorySharedPtr
-  createFromProto(const Protobuf::Message&) override {
-    return std::make_shared<PreserveCaseFormatterFactory>();
-  }
-  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
-    return std::make_unique<envoy::extensions::http::header_formatters::preserve_case::v3::
-                                PreserveCaseFormatterConfig>();
-  }
-};
+absl::string_view PreserveCaseHeaderFormatter::getReasonPhrase() const { return {reason_phrase_}; };
 
-REGISTER_FACTORY(PreserveCaseFormatterFactoryConfig,
-                 Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig);
+Envoy::Http::HeaderKeyFormatterOptConstRef
+PreserveCaseHeaderFormatter::formatterOnEnvoyHeaders() const {
+  return makeOptRefFromPtr(header_key_formatter_on_enovy_headers_.get());
+}
 
 } // namespace PreserveCase
 } // namespace HeaderFormatters

--- a/source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.h
+++ b/source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "envoy/common/exception.h"
+#include "envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.pb.h"
 #include "envoy/http/header_formatter.h"
 
 #include "common/common/utility.h"
@@ -14,12 +16,24 @@ namespace PreserveCase {
 class PreserveCaseHeaderFormatter : public Envoy::Http::StatefulHeaderKeyFormatter {
 public:
   // Envoy::Http::StatefulHeaderKeyFormatter
+  PreserveCaseHeaderFormatter(
+      const bool forward_reason_phrase,
+      const envoy::extensions::http::header_formatters::preserve_case::v3::
+          PreserveCaseFormatterConfig::FormatterTypeOnEnvoyHeaders formatter_type_on_envoy_headers);
+
   std::string format(absl::string_view key) const override;
   void processKey(absl::string_view key) override;
+  void setReasonPhrase(absl::string_view reason_phrase) override;
+  absl::string_view getReasonPhrase() const override;
+  Envoy::Http::HeaderKeyFormatterOptConstRef formatterOnEnvoyHeaders() const;
 
 private:
   StringUtil::CaseUnorderedSet original_header_keys_;
-  Envoy::Http::Http1::ProperCaseHeaderKeyFormatter proper_case_header_key_formatter_;
+  bool forward_reason_phrase_{false};
+  std::string reason_phrase_;
+  const envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+      FormatterTypeOnEnvoyHeaders formatter_type_on_envoy_headers_;
+  Envoy::Http::HeaderKeyFormatterConstPtr header_key_formatter_on_enovy_headers_;
 };
 
 } // namespace PreserveCase

--- a/test/extensions/http/header_formatters/preserve_case/BUILD
+++ b/test/extensions/http/header_formatters/preserve_case/BUILD
@@ -19,6 +19,7 @@ envoy_extension_cc_test(
     extension_name = "envoy.http.stateful_header_formatters.preserve_case",
     deps = [
         "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",
+        "//test/test_common:utility_lib",
     ],
 )
 
@@ -29,7 +30,22 @@ envoy_extension_cc_test(
     ],
     extension_name = "envoy.http.stateful_header_formatters.preserve_case",
     deps = [
+        "//source/extensions/http/header_formatters/preserve_case:config",
         "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",
         "//test/integration:http_integration_lib",
+        "@envoy_api//envoy/extensions/http/header_formatters/preserve_case/v3:pkg_cc_proto",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "config_test",
+    srcs = ["config_test.cc"],
+    extension_name = "envoy.http.stateful_header_formatters.preserve_case",
+    deps = [
+        "//include/envoy/registry",
+        "//source/common/common:utility_lib",
+        "//source/extensions/http/header_formatters/preserve_case:config",
+        "//source/extensions/http/header_formatters/preserve_case:preserve_case_formatter",
+        "//test/test_common:utility_lib",
     ],
 )

--- a/test/extensions/http/header_formatters/preserve_case/config_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/config_test.cc
@@ -1,0 +1,109 @@
+#include "envoy/registry/registry.h"
+
+#include "common/config/utility.h"
+#include "extensions/http/header_formatters/preserve_case/config.h"
+#include "extensions/http/header_formatters/preserve_case/preserve_case_formatter.h"
+
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace Http {
+namespace HeaderFormatters {
+namespace PreserveCase {
+
+TEST(PreserveCaseFormatterFactoryConfigTest, Basic) {
+  auto* factory =
+      Registry::FactoryRegistry<Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig>::getFactory(
+          "preserve_case");
+  ASSERT_NE(factory, nullptr);
+
+  envoy::config::core::v3::TypedExtensionConfig typed_config;
+  const std::string yaml = R"EOF(
+    name: preserve_case
+    typed_config:
+        "@type": type.googleapis.com/envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig
+        forward_reason_phrase: false
+        formatter_type_on_envoy_headers: DEFAULT
+)EOF";
+  TestUtility::loadFromYaml(yaml, typed_config);
+  auto header_formatter_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
+      typed_config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), *factory);
+  EXPECT_NE(factory->createFromProto(*header_formatter_config), nullptr);
+}
+
+TEST(PreserveCaseFormatterFactoryConfigTest, InvalidfFormatterTypeOnEnvoyHeaders) {
+  auto* factory =
+      Registry::FactoryRegistry<Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig>::getFactory(
+          "preserve_case");
+  ASSERT_NE(factory, nullptr);
+
+  envoy::config::core::v3::TypedExtensionConfig typed_config;
+  const std::string yaml = R"EOF(
+    name: preserve_case
+    typed_config:
+        "@type": type.googleapis.com/envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig
+        forward_reason_phrase: true
+        formatter_type_on_envoy_headers: INVALID
+)EOF";
+  EXPECT_THROW_WITH_REGEX(
+      TestUtility::loadFromYaml(yaml, typed_config);
+      , EnvoyException,
+      "Unable to parse JSON as proto \\(INVALID_ARGUMENT:\\(formatter_type_on_envoy_headers\\):.*");
+}
+
+TEST(PreserveCaseFormatterFactoryConfigTest, PreserveCaseFormatterFactoryConfig_DEFAULT) {
+  auto* factory =
+      Registry::FactoryRegistry<Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig>::getFactory(
+          "preserve_case");
+  envoy::config::core::v3::TypedExtensionConfig typed_config;
+  const std::string yaml = R"EOF(
+    name: preserve_case
+    typed_config:
+        "@type": type.googleapis.com/envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig
+        forward_reason_phrase: false
+        formatter_type_on_envoy_headers: DEFAULT
+)EOF";
+  TestUtility::loadFromYaml(yaml, typed_config);
+  auto header_formatter_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
+      typed_config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), *factory);
+  auto formatter_factory = factory->createFromProto(*header_formatter_config);
+  auto formatter = formatter_factory->create();
+
+  formatter->processKey("Foo");
+  EXPECT_EQ("Foo", formatter->format("foo"));
+  EXPECT_EQ("Foo", formatter->format("Foo"));
+  EXPECT_EQ("hello-world", formatter->format("hello-world"));
+}
+
+TEST(PreserveCaseFormatterFactoryConfigTest, PreserveCaseFormatterFactoryConfig_PROPER_CASE) {
+  auto* factory =
+      Registry::FactoryRegistry<Envoy::Http::StatefulHeaderKeyFormatterFactoryConfig>::getFactory(
+          "preserve_case");
+  envoy::config::core::v3::TypedExtensionConfig typed_config;
+  const std::string yaml = R"EOF(
+    name: preserve_case
+    typed_config:
+        "@type": type.googleapis.com/envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig
+        forward_reason_phrase: false
+        formatter_type_on_envoy_headers: PROPER_CASE
+)EOF";
+  TestUtility::loadFromYaml(yaml, typed_config);
+  auto header_formatter_config = Envoy::Config::Utility::translateAnyToFactoryConfig(
+      typed_config.typed_config(), ProtobufMessage::getStrictValidationVisitor(), *factory);
+  auto formatter_factory = factory->createFromProto(*header_formatter_config);
+  auto formatter = formatter_factory->create();
+
+  formatter->processKey("Foo");
+  EXPECT_EQ("Foo", formatter->format("foo"));
+  EXPECT_EQ("Foo", formatter->format("Foo"));
+  EXPECT_EQ("Hello-World", formatter->format("hello-world"));
+}
+
+} // namespace PreserveCase
+} // namespace HeaderFormatters
+} // namespace Http
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_integration_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_integration_test.cc
@@ -1,9 +1,39 @@
+#include "envoy/extensions/http/header_formatters/preserve_case/v3/preserve_case.pb.h"
+
 #include "test/integration/filters/common.h"
 #include "test/integration/http_integration.h"
 #include "test/test_common/registry.h"
 
 namespace Envoy {
 namespace {
+
+struct FormatterOnEnvoyHeadersTestParams {
+  Network::Address::IpVersion ip_version;
+  envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+      FormatterTypeOnEnvoyHeaders formatter_type_on_envoy_headers;
+};
+
+std::string formatterOnEnvoyHeadersTestParamsToString(
+    const ::testing::TestParamInfo<FormatterOnEnvoyHeadersTestParams>& p) {
+  return fmt::format("{}_{}",
+                     p.param.ip_version == Network::Address::IpVersion::v4 ? "IPv4" : "IPv6",
+                     p.param.formatter_type_on_envoy_headers);
+}
+
+std::vector<FormatterOnEnvoyHeadersTestParams> getFormatterOnEnvoyHeadersTestParams() {
+  std::vector<FormatterOnEnvoyHeadersTestParams> ret;
+
+  for (auto ip_version : TestEnvironment::getIpVersionsForTest()) {
+    ret.push_back(FormatterOnEnvoyHeadersTestParams{
+        ip_version, envoy::extensions::http::header_formatters::preserve_case::v3::
+                        PreserveCaseFormatterConfig::DEFAULT});
+    ret.push_back(FormatterOnEnvoyHeadersTestParams{
+        ip_version, envoy::extensions::http::header_formatters::preserve_case::v3::
+                        PreserveCaseFormatterConfig::PROPER_CASE});
+  }
+
+  return ret;
+}
 
 // Demonstrate using a filter to affect the case.
 class PreserveCaseFilter : public Http::PassThroughFilter {
@@ -13,37 +43,45 @@ public:
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override {
     headers.addCopy(Http::LowerCaseString("request-header"), "request-header-value");
     headers.formatter()->processKey("Request-Header");
+
     headers.addCopy(Http::LowerCaseString("x-forwarded-for"), "x-forwarded-for-value");
+
     return Http::FilterHeadersStatus::Continue;
   }
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers, bool) override {
     headers.addCopy(Http::LowerCaseString("response-header"), "response-header-value");
     headers.formatter()->processKey("Response-Header");
-    headers.addCopy(Http::LowerCaseString("server"), "server-value");
+
+    headers.addCopy(Http::LowerCaseString("hello-header"), "hello-header-value");
+
     return Http::FilterHeadersStatus::Continue;
   }
 };
 
 constexpr char PreserveCaseFilter::name[];
 
-class PreserveCaseIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
-                                    public HttpIntegrationTest {
+class PreserveCaseIntegrationTest
+    : public testing::TestWithParam<FormatterOnEnvoyHeadersTestParams>,
+      public HttpIntegrationTest {
 public:
   PreserveCaseIntegrationTest()
-      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam()), registration_(factory_) {}
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, GetParam().ip_version),
+        registration_(factory_) {}
 
   void initialize() override {
-    config_helper_.addConfigModifier([](envoy::extensions::filters::network::
-                                            http_connection_manager::v3::HttpConnectionManager&
-                                                hcm) {
-      auto typed_extension_config = hcm.mutable_http_protocol_options()
-                                        ->mutable_header_key_format()
-                                        ->mutable_stateful_formatter();
-      typed_extension_config->set_name("preserve_case");
-      typed_extension_config->mutable_typed_config()->set_type_url(
-          "type.googleapis.com/"
-          "envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig");
-    });
+    config_helper_.addConfigModifier(
+        [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+               hcm) {
+          auto typed_extension_config = hcm.mutable_http_protocol_options()
+                                            ->mutable_header_key_format()
+                                            ->mutable_stateful_formatter();
+          typed_extension_config->set_name("preserve_case");
+          auto config = TestUtility::parseYaml<envoy::extensions::http::header_formatters::
+                                                   preserve_case::v3::PreserveCaseFormatterConfig>(
+              fmt::format("formatter_type_on_envoy_headers: {}",
+                          GetParam().formatter_type_on_envoy_headers));
+          typed_extension_config->mutable_typed_config()->PackFrom(config);
+        });
 
     config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
       ConfigHelper::HttpProtocolOptions protocol_options;
@@ -52,9 +90,11 @@ public:
                                         ->mutable_header_key_format()
                                         ->mutable_stateful_formatter();
       typed_extension_config->set_name("preserve_case");
-      typed_extension_config->mutable_typed_config()->set_type_url(
-          "type.googleapis.com/"
-          "envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig");
+      auto config =
+          TestUtility::parseYaml<envoy::extensions::http::header_formatters::preserve_case::v3::
+                                     PreserveCaseFormatterConfig>(fmt::format(
+              "formatter_type_on_envoy_headers: {}", GetParam().formatter_type_on_envoy_headers));
+      typed_extension_config->mutable_typed_config()->PackFrom(config);
       ConfigHelper::setProtocolOptions(*bootstrap.mutable_static_resources()->mutable_clusters(0),
                                        protocol_options);
     });
@@ -67,8 +107,8 @@ public:
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, PreserveCaseIntegrationTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
-                         TestUtility::ipTestParamsToString);
+                         testing::ValuesIn(getFormatterOnEnvoyHeadersTestParams()),
+                         formatterOnEnvoyHeadersTestParamsToString);
 
 // Verify that we preserve case in both directions.
 TEST_P(PreserveCaseIntegrationTest, EndToEnd) {
@@ -92,7 +132,19 @@ TEST_P(PreserveCaseIntegrationTest, EndToEnd) {
   EXPECT_TRUE(absl::StrContains(upstream_request, "My-Request-Header: foo"));
   EXPECT_TRUE(absl::StrContains(upstream_request, "HOst: host"));
   EXPECT_TRUE(absl::StrContains(upstream_request, "Request-Header: request-header-value"));
-  EXPECT_TRUE(absl::StrContains(upstream_request, "X-Forwarded-For: 1.2.3.4"));
+  switch (GetParam().formatter_type_on_envoy_headers) {
+  case envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+      DEFAULT:
+    EXPECT_TRUE(absl::StrContains(upstream_request, "x-forwarded-for: x-forwarded-for-value"));
+    break;
+  case envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+      PROPER_CASE:
+    EXPECT_TRUE(absl::StrContains(upstream_request, "X-Forwarded-For: x-forwarded-for-value"));
+    break;
+  default:
+    EXPECT_TRUE(absl::StrContains(upstream_request, "x-forwarded-for: x-forwarded-for-value"));
+    break;
+  }
 
   // Verify that the downstream response has preserved cased headers.
   auto response =
@@ -103,7 +155,20 @@ TEST_P(PreserveCaseIntegrationTest, EndToEnd) {
   tcp_client->waitForData("Content-Length: 0", false);
   tcp_client->waitForData("My-Response-Header: foo", false);
   tcp_client->waitForData("Response-Header: response-header-value", false);
-  tcp_client->waitForData("Server: server-value", false);
+  switch (GetParam().formatter_type_on_envoy_headers) {
+  case envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+      DEFAULT:
+    tcp_client->waitForData("hello-header: hello-header-value", false);
+    break;
+  case envoy::extensions::http::header_formatters::preserve_case::v3::PreserveCaseFormatterConfig::
+      PROPER_CASE:
+    tcp_client->waitForData("Hello-Header: hello-header-value", false);
+    break;
+  default:
+    tcp_client->waitForData("hello-header: hello-header-value", false);
+    break;
+  }
+
   tcp_client->close();
 }
 

--- a/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_test.cc
+++ b/test/extensions/http/header_formatters/preserve_case/preserve_case_formatter_test.cc
@@ -1,5 +1,7 @@
 #include "extensions/http/header_formatters/preserve_case/preserve_case_formatter.h"
 
+#include "test/test_common/utility.h"
+
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -9,7 +11,45 @@ namespace HeaderFormatters {
 namespace PreserveCase {
 
 TEST(PreserveCaseFormatterTest, All) {
-  PreserveCaseHeaderFormatter formatter;
+  PreserveCaseHeaderFormatter formatter(false,
+                                        envoy::extensions::http::header_formatters::preserve_case::
+                                            v3::PreserveCaseFormatterConfig::DEFAULT);
+  formatter.processKey("Foo");
+  formatter.processKey("Bar");
+  formatter.processKey("BAR");
+
+  EXPECT_EQ("Foo", formatter.format("foo"));
+  EXPECT_EQ("Foo", formatter.format("Foo"));
+  EXPECT_EQ("Bar", formatter.format("bar"));
+  EXPECT_EQ("Bar", formatter.format("Bar"));
+  EXPECT_EQ("Bar", formatter.format("BAR"));
+  EXPECT_EQ("baz", formatter.format("baz"));
+}
+
+TEST(PreserveCaseFormatterTest, ReasonPhraseEnabled) {
+  PreserveCaseHeaderFormatter formatter(true,
+                                        envoy::extensions::http::header_formatters::preserve_case::
+                                            v3::PreserveCaseFormatterConfig::DEFAULT);
+
+  formatter.setReasonPhrase(absl::string_view("Slow Down"));
+
+  EXPECT_EQ("Slow Down", formatter.getReasonPhrase());
+}
+
+TEST(PreserveCaseFormatterTest, ReasonPhraseDisabled) {
+  PreserveCaseHeaderFormatter formatter(false,
+                                        envoy::extensions::http::header_formatters::preserve_case::
+                                            v3::PreserveCaseFormatterConfig::DEFAULT);
+
+  formatter.setReasonPhrase(absl::string_view("Slow Down"));
+
+  EXPECT_TRUE(formatter.getReasonPhrase().empty());
+}
+
+TEST(PreserveCaseFormatterTest, ProperCaseFormatterOnEnvoyHeadersEnabled) {
+  PreserveCaseHeaderFormatter formatter(false,
+                                        envoy::extensions::http::header_formatters::preserve_case::
+                                            v3::PreserveCaseFormatterConfig::PROPER_CASE);
   formatter.processKey("Foo");
   formatter.processKey("Bar");
   formatter.processKey("BAR");
@@ -20,8 +60,38 @@ TEST(PreserveCaseFormatterTest, All) {
   EXPECT_EQ("Bar", formatter.format("Bar"));
   EXPECT_EQ("Bar", formatter.format("BAR"));
   EXPECT_EQ("Baz", formatter.format("baz"));
-  EXPECT_EQ("HeLLO", formatter.format("heLLO"));
   EXPECT_EQ("Hello-World", formatter.format("hello-world"));
+  EXPECT_EQ("Hello#WORLD", formatter.format("hello#wORLD"));
+
+  EXPECT_EQ(true, formatter.formatterOnEnvoyHeaders().has_value());
+}
+
+TEST(PreserveCaseFormatterTest, DefaultFormatterOnEnvoyHeadersEnabled) {
+  PreserveCaseHeaderFormatter formatter(false,
+                                        envoy::extensions::http::header_formatters::preserve_case::
+                                            v3::PreserveCaseFormatterConfig::DEFAULT);
+  formatter.processKey("Foo");
+  formatter.processKey("Bar");
+  formatter.processKey("BAR");
+
+  EXPECT_EQ("Foo", formatter.format("foo"));
+  EXPECT_EQ("Foo", formatter.format("Foo"));
+  EXPECT_EQ("Bar", formatter.format("bar"));
+  EXPECT_EQ("Bar", formatter.format("Bar"));
+  EXPECT_EQ("Bar", formatter.format("BAR"));
+  EXPECT_EQ("baz", formatter.format("baz"));
+  EXPECT_EQ("hello-world", formatter.format("hello-world"));
+  EXPECT_EQ("hello#wORLD", formatter.format("hello#wORLD"));
+
+  EXPECT_EQ(false, formatter.formatterOnEnvoyHeaders().has_value());
+}
+
+TEST(PreserveCaseFormatterTest, InvalidFormatterOnEnvoyHeaders) {
+  EXPECT_THROW_WITH_REGEX(
+      PreserveCaseHeaderFormatter formatter(
+          false, static_cast<envoy::extensions::http::header_formatters::preserve_case::v3::
+                                 PreserveCaseFormatterConfig::FormatterTypeOnEnvoyHeaders>(-1)),
+      EnvoyException, "Not supported FormatterTypeOnEnvoyHeaders:.*");
 }
 
 } // namespace PreserveCase

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2088,7 +2088,7 @@ TEST_P(DownstreamProtocolIntegrationTest, MaxRequestsPerConnectionReached) {
   EXPECT_EQ(test_server_->counter("http.config_test.downstream_cx_max_requests_reached")->value(),
             1);
 
-  if (downstream_protocol_ == Http::CodecType::HTTP1) {
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
     EXPECT_EQ(nullptr, response->headers().Connection());
     EXPECT_EQ("close", response_2->headers().getConnectionValue());
   } else {


### PR DESCRIPTION
cherry pick preserve case on envoy headers

https://github.com/envoyproxy/envoy/pull/20780

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
